### PR TITLE
response.contentType() ignores parameter

### DIFF
--- a/src/models/response.js
+++ b/src/models/response.js
@@ -163,7 +163,7 @@ SolidResponse.prototype.aclAbsoluteUrl = function aclAbsoluteUrl () {
  */
 SolidResponse.prototype.contentType = function contentType () {
   if (this.xhr) {
-    return this.xhr.getResponseHeader('Content-Type')
+    return this.xhr.getResponseHeader('Content-Type').split(';')[0] // remove parameter
   } else {
     return null
   }

--- a/test/unit/solid-response-test.js
+++ b/test/unit/solid-response-test.js
@@ -76,3 +76,20 @@ test('SolidResonse full IRI based on Location header', t => {
   t.equal(response.url, 'https://foo.example/dan')
   t.end()
 })
+
+test('SolidResonse ignore parameter in Content-Type header', t => {
+  let stub = sinon.stub()
+  stub.withArgs('Link').returns(null)
+  let xhr = { getResponseHeader: stub }
+  let response
+
+  stub.withArgs('Content-Type').returns('text/turtle')
+  response = new SolidResponse(null, xhr, 'POST')
+  t.equal(response.contentType(), 'text/turtle')
+
+  stub.withArgs('Content-Type').returns('text/turtle; charset=UTF-8')
+  response = new SolidResponse(null, xhr, 'POST')
+  t.equal(response.contentType(), 'text/turtle')
+
+  t.end()
+})


### PR DESCRIPTION
based on my experience with https://www.wikidata.org responses failing to parse, now they parse with this patch